### PR TITLE
feat(op-geth): add combo mainnet chain config

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -385,7 +385,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	// on top of an existing private network genesis block). In that case, only
 	// apply the overrides.
 	if genesis == nil && stored != params.MainnetGenesisHash && stored != params.OPBNBMainNetGenesisHash &&
-		stored != params.OPBNBTestNetGenesisHash && stored != params.OPBNBDevNetGenesisHash {
+		stored != params.OPBNBTestNetGenesisHash && stored != params.OPBNBDevNetGenesisHash && stored != params.ComboMainNetGenesisHash {
 		newcfg = storedcfg
 		applyOverrides(newcfg)
 	}
@@ -460,6 +460,8 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 		return params.OPBNBTestNetConfig
 	case ghash == params.OPBNBDevNetGenesisHash:
 		return params.OPBNBDevNetConfig
+	case ghash == params.ComboMainNetGenesisHash:
+		return params.ComboMainNetConfig
 	default:
 		return params.AllEthashProtocolChanges
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -36,6 +36,8 @@ var (
 	OPBNBMainNetGenesisHash = common.HexToHash("0x4dd61178c8b0f01670c231597e7bcb368e84545acd46d940a896d6a791dd6df4")
 	OPBNBTestNetGenesisHash = common.HexToHash("0x51fa57729dfb1c27542c21b06cb72a0459c57440ceb43a465dae1307cd04fe80")
 	OPBNBDevNetGenesisHash  = common.HexToHash("0x49d448b8dc98cc95e3968615ff3dbd904d9eec8252c5f52271f029896e6147ee")
+
+	ComboMainNetGenesisHash = common.HexToHash("0x92fcf9e91a4cdd7ffc7e67207e77dfba049bacf1ede5c5917a40f9537e05f4bc")
 )
 
 // OP Stack chain config
@@ -321,6 +323,34 @@ var (
 			EIP1559Denominator: 8,
 		},
 		Fermat: big.NewInt(3615117),
+	}
+
+	ComboMainNetConfig = &ChainConfig{
+		ChainID:                       big.NewInt(9980),
+		HomesteadBlock:                big.NewInt(0),
+		EIP150Block:                   big.NewInt(0),
+		EIP150Hash:                    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		EIP155Block:                   big.NewInt(0),
+		EIP158Block:                   big.NewInt(0),
+		ByzantiumBlock:                big.NewInt(0),
+		ConstantinopleBlock:           big.NewInt(0),
+		PetersburgBlock:               big.NewInt(0),
+		IstanbulBlock:                 big.NewInt(0),
+		MuirGlacierBlock:              big.NewInt(0),
+		BerlinBlock:                   big.NewInt(0),
+		LondonBlock:                   big.NewInt(0),
+		ArrowGlacierBlock:             big.NewInt(0),
+		GrayGlacierBlock:              big.NewInt(0),
+		MergeNetsplitBlock:            big.NewInt(0),
+		BedrockBlock:                  big.NewInt(0),
+		RegolithTime:                  newUint64(0),
+		TerminalTotalDifficulty:       big.NewInt(0),
+		TerminalTotalDifficultyPassed: true,
+		Optimism: &OptimismConfig{
+			EIP1559Elasticity:  2,
+			EIP1559Denominator: 8,
+		},
+		Fermat: big.NewInt(0),
 	}
 
 	// AllEthashProtocolChanges contains every protocol change (EIPs) introduced


### PR DESCRIPTION
### Description

Add combo mainnet chain config.

### Rationale

In order to start and upgrade combo-op-geth more safely and conveniently.

### Example

N/A.

### Changes

Add combo mainnet chain config.
